### PR TITLE
feat(core): Phase 2A — createSyntropyLog() factory + ISyntropyLog int…

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -4,6 +4,53 @@ SyntropyLog runs a small state machine: `INITIALIZING → READY → SHUTTING_DOW
 
 ---
 
+## Getting a SyntropyLog instance
+
+Two equivalent entry points — pick the one that fits the call site:
+
+| Entry point | What you get | When to use |
+|---|---|---|
+| `import { syntropyLog }` | The process-wide singleton (created on first import) | App-level code where one logger config serves the whole process. **Default for most apps.** |
+| `createSyntropyLog()` | A fresh, fully-independent instance (an `ISyntropyLog`) | Multi-tenant scenarios, parallel tests that need isolation, micro-frontends, anywhere "two SyntropyLogs in one process" is real |
+
+Both objects implement the same `ISyntropyLog` interface — the rest of your code can type against the interface and stay agnostic about how the instance was obtained:
+
+```typescript
+import type { ISyntropyLog } from 'syntropylog';
+
+function buildAuditLogger(sl: ISyntropyLog) {
+  return sl.getLogger('audit').withRetention('SOX_AUDIT_TRAIL');
+}
+```
+
+### Factory example — isolated instances
+
+```typescript
+import { createSyntropyLog } from 'syntropylog';
+
+const acmeLogging = createSyntropyLog();
+await acmeLogging.init({
+  logger: { serviceName: 'tenant-acme', level: 'info' },
+  retentionPolicies: { ACME_AUDIT: { years: 5 } },
+});
+
+const initechLogging = createSyntropyLog();
+await initechLogging.init({
+  logger: { serviceName: 'tenant-initech', level: 'warn' },
+});
+
+// Independent EventEmitters, configs, hooks, and stats.
+acmeLogging.getLogger().info('hello from acme');
+initechLogging.getLogger().warn('hello from initech');
+
+await acmeLogging.shutdown();
+await initechLogging.shutdown();
+```
+
+The factory does not touch the singleton — calling `createSyntropyLog()` never affects `syntropyLog` and vice versa. Factory instances also bypass `SyntropyLog.resetInstance()` / `_resetForTesting()`, so parallel tests get genuine isolation by construction.
+
+---
+
 ## `init` and `shutdown`
 
 `init()` returns a `Promise<void>` that resolves when the framework is fully ready. Until it resolves, `getLogger()` returns a no-op logger that drops messages.

--- a/src/ISyntropyLog.ts
+++ b/src/ISyntropyLog.ts
@@ -1,0 +1,75 @@
+/**
+ * @file src/ISyntropyLog.ts
+ * @description Public contract for a SyntropyLog instance.
+ *
+ * Defines `ISyntropyLog` (the interface every instance fulfills) and
+ * `SyntropyLogStats` (the snapshot shape returned by `getStats()`).
+ *
+ * Use this interface when typing dependencies that should work with either the
+ * global singleton (`syntropyLog`) or an instance produced by the factory
+ * (`createSyntropyLog()`):
+ *
+ * ```typescript
+ * import type { ISyntropyLog } from 'syntropylog';
+ *
+ * function buildAuditLogger(sl: ISyntropyLog) {
+ *   return sl.getLogger('audit').withRetention('SOX_AUDIT_TRAIL');
+ * }
+ * ```
+ *
+ * The interface intentionally excludes static/singleton helpers
+ * (`getInstance`, `resetInstance`, `_resetForTesting`) — those belong to the
+ * concrete `SyntropyLog` class, not the per-instance contract.
+ */
+
+import type { EventEmitter } from 'events';
+import type { SyntropyLogConfig } from './config';
+import type { IContextManager } from './context';
+import type { ILogger } from './logger';
+import type { SyntropyLogState } from './core/LifecycleManager';
+import type { LogLevel } from './logger/levels';
+import type { LoggingMatrix, JsonValue } from './types';
+import type { ReconfigureTransportsForDebugOptions } from './logger/LoggerFactory';
+import type { StatsSnapshot } from './observability/StatsCollector';
+import type { MaskingEngine } from './masking/MaskingEngine';
+import type { SerializationManager } from './serialization/SerializationManager';
+
+/**
+ * Full health snapshot returned by {@link ISyntropyLog.getStats}.
+ *
+ * Combines the failure counters owned by the StatsCollector (`StatsSnapshot`)
+ * with `state` and `nativeAddonActive` — fields that only the LifecycleManager
+ * and serializer can answer authoritatively.
+ */
+export interface SyntropyLogStats extends StatsSnapshot {
+  state: SyntropyLogState;
+  /** True if the Rust native addon is loaded and used for serialization. */
+  nativeAddonActive: boolean;
+}
+
+/**
+ * The contract implemented by every SyntropyLog instance.
+ *
+ * Extends `EventEmitter` so consumers can subscribe to lifecycle events
+ * (`ready`, `error`, `shutting_down`, `transports_drained`, `shutdown`).
+ * Those events are internal coordination signals — prefer `await init()` /
+ * `await shutdown()` in application code (see `docs/lifecycle.md`).
+ */
+export interface ISyntropyLog extends EventEmitter {
+  getState(): SyntropyLogState;
+  init(config: SyntropyLogConfig): Promise<void>;
+  shutdown(): Promise<void>;
+  getLogger(name?: string, bindings?: Record<string, JsonValue>): ILogger;
+  getContextManager(): IContextManager;
+  getConfig(): SyntropyLogConfig;
+  getFilteredContext(level: LogLevel): Record<string, unknown>;
+  reconfigureLoggingMatrix(matrix: LoggingMatrix): void;
+  reconfigureTransportsForDebug(
+    options: ReconfigureTransportsForDebugOptions
+  ): void;
+  resetTransports(): void;
+  getMasker(): MaskingEngine;
+  getSerializer(): SerializationManager;
+  isNativeAddonInUse(): boolean;
+  getStats(): SyntropyLogStats;
+}

--- a/src/SyntropyLog.ts
+++ b/src/SyntropyLog.ts
@@ -1,9 +1,23 @@
 /**
  * @file src/SyntropyLog.ts
- * @description The main public-facing singleton class for the SyntropyLog framework.
- * This class acts as a Facade, providing a simple and clean API surface
- * while delegating all complex lifecycle and orchestration work to the internal
- * LifecycleManager.
+ * @description The main public-facing class for the SyntropyLog framework.
+ *
+ * Two ways to obtain an instance:
+ *
+ * 1. **Global singleton** — `import { syntropyLog } from 'syntropylog'`.
+ *    Most apps want one shared logger; this is the default and matches the
+ *    behavior the framework has always had.
+ *
+ * 2. **Factory** — `import { createSyntropyLog } from 'syntropylog'`.
+ *    Returns an `ISyntropyLog` instance that is fully independent of the
+ *    singleton and of any other factory-produced instances. Use for
+ *    multi-tenant apps, parallel tests that need isolation, micro-frontends,
+ *    or any scenario where "two SyntropyLogs in one process" is real.
+ *
+ * Both paths return objects that implement `ISyntropyLog` — the same method
+ * surface, the same EventEmitter contract, the same lifecycle. Pick whichever
+ * fits the call site; the rest of the codebase can type against `ISyntropyLog`
+ * to stay agnostic.
  */
 import { EventEmitter } from 'events';
 import { SyntropyLogConfig } from './config';
@@ -13,18 +27,11 @@ import { LifecycleManager, SyntropyLogState } from './core/LifecycleManager';
 import { LogLevel } from './logger/levels';
 import { LoggingMatrix, JsonValue } from './types';
 import type { ReconfigureTransportsForDebugOptions } from './logger/LoggerFactory';
-import type { StatsSnapshot } from './observability/StatsCollector';
+import type { ISyntropyLog, SyntropyLogStats } from './ISyntropyLog';
 
-/**
- * Full health snapshot returned by {@link SyntropyLog.getStats}.
- * Combines the failure counters owned by the StatsCollector with current state
- * and the native-addon flag, which only the LifecycleManager / serializer can answer.
- */
-export interface SyntropyLogStats extends StatsSnapshot {
-  state: SyntropyLogState;
-  /** True if the Rust native addon is loaded and used for serialization. */
-  nativeAddonActive: boolean;
-}
+// Re-export so existing `import { SyntropyLogStats } from 'syntropylog'` paths keep working.
+export type { SyntropyLogStats } from './ISyntropyLog';
+export type { ISyntropyLog } from './ISyntropyLog';
 
 /** Pure: throws if value is null/undefined; returns value otherwise. Use for guard clauses. */
 function requireDefined<T>(
@@ -38,14 +45,21 @@ function requireDefined<T>(
 
 /**
  * @class SyntropyLog
- * @description The main public entry point for the framework. It follows the
- * Singleton pattern and acts as an EventEmitter to report on its lifecycle,
- * proxying events from its internal LifecycleManager.
+ * @description The main framework class. Acts as a Facade over `LifecycleManager`,
+ * exposing the public surface declared by {@link ISyntropyLog} and proxying lifecycle
+ * events. Instances are obtained via the global singleton (`syntropyLog`) or via
+ * the {@link createSyntropyLog} factory.
  */
-export class SyntropyLog extends EventEmitter {
+export class SyntropyLog extends EventEmitter implements ISyntropyLog {
   private static instance: SyntropyLog;
   private readonly lifecycleManager: LifecycleManager;
 
+  /**
+   * Private to keep `new SyntropyLog()` out of the public surface — pick one
+   * of the supported entry points instead:
+   * - {@link SyntropyLog.getInstance} for the singleton (default for app code).
+   * - {@link createSyntropyLog} for a fresh, independent instance.
+   */
   private constructor() {
     super();
     this.lifecycleManager = new LifecycleManager(this);
@@ -60,6 +74,12 @@ export class SyntropyLog extends EventEmitter {
     this.lifecycleManager.on('shutdown', () => this.emit('shutdown'));
   }
 
+  /**
+   * Returns the process-wide singleton instance, creating it on first call.
+   * Recommended for app-level usage where one logger config serves the whole
+   * process. For multi-tenant, parallel tests, or any scenario that needs
+   * isolation, use {@link createSyntropyLog} instead.
+   */
   public static getInstance(): SyntropyLog {
     if (!SyntropyLog.instance) {
       SyntropyLog.instance = new SyntropyLog();
@@ -68,8 +88,19 @@ export class SyntropyLog extends EventEmitter {
   }
 
   /**
+   * Creates a brand-new instance that does not share state with the singleton
+   * or any other instance. Each instance has its own EventEmitter,
+   * LifecycleManager, StatsCollector, and registered hooks. Backing the
+   * {@link createSyntropyLog} factory.
+   */
+  public static create(): SyntropyLog {
+    return new SyntropyLog();
+  }
+
+  /**
    * Internal test helper to reset the singleton instance.
-   * DO NOT USE in production code.
+   * Prefer `createSyntropyLog()` for new test code — it gives genuine
+   * isolation without touching global state.
    */
   public static resetInstance(): void {
     // Intentional reset for tests; instance is private
@@ -199,6 +230,36 @@ export class SyntropyLog extends EventEmitter {
     this.lifecycleManager.on('shutting_down', () => this.emit('shutting_down'));
     this.lifecycleManager.on('shutdown', () => this.emit('shutdown'));
   }
+}
+
+/**
+ * Returns a fresh, fully-independent SyntropyLog instance.
+ *
+ * The returned object implements {@link ISyntropyLog} and shares no state
+ * (config, lifecycle, stats, hooks, EventEmitter listeners) with the global
+ * `syntropyLog` singleton or with any other factory-produced instance.
+ *
+ * Typical scenarios:
+ *
+ * - **Multi-tenant** apps where two tenants need different log routing.
+ * - **Parallel tests** that need isolated frameworks without touching
+ *   `SyntropyLog.resetInstance()` or `_resetForTesting()`.
+ * - **Micro-frontends** or other architectures that load SyntropyLog from
+ *   more than one module-graph root.
+ *
+ * Each instance must be initialized independently:
+ *
+ * ```typescript
+ * import { createSyntropyLog } from 'syntropylog';
+ *
+ * const sl = createSyntropyLog();
+ * await sl.init({ logger: { serviceName: 'tenant-acme' } });
+ * sl.getLogger().info('hello from acme');
+ * await sl.shutdown();
+ * ```
+ */
+export function createSyntropyLog(): ISyntropyLog {
+  return SyntropyLog.create();
 }
 
 /** The singleton instance of the SyntropyLog framework. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@
  */
 
 // --- Main Framework Class ---
-export { syntropyLog, SyntropyLog } from './SyntropyLog';
-export type { SyntropyLogStats } from './SyntropyLog';
+export { syntropyLog, SyntropyLog, createSyntropyLog } from './SyntropyLog';
+export type { ISyntropyLog, SyntropyLogStats } from './ISyntropyLog';
 export type {
   StatsSnapshot,
   StatsFailureCounts,

--- a/src/type-exports.ts
+++ b/src/type-exports.ts
@@ -20,8 +20,8 @@ export type { LogLevel } from './logger/levels';
 export type { LogFormatter } from './logger/transports/formatters/LogFormatter';
 
 // --- Main Framework Exports ---
-export { SyntropyLog, syntropyLog } from './SyntropyLog';
-export type { SyntropyLogStats } from './SyntropyLog';
+export { SyntropyLog, syntropyLog, createSyntropyLog } from './SyntropyLog';
+export type { ISyntropyLog, SyntropyLogStats } from './ISyntropyLog';
 export type {
   StatsSnapshot,
   StatsFailureCounts,

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -51,6 +51,7 @@ exports[`Main entry point (src/index.ts) > should match the public API snapshot 
   "Transport",
   "UniversalAdapter",
   "UniversalLogFormatter",
+  "createSyntropyLog",
   "defineMatrix",
   "defineRetentionPolicies",
   "extractInboundContext",

--- a/tests/factory.test.ts
+++ b/tests/factory.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createSyntropyLog,
+  SyntropyLog,
+  syntropyLog as globalSyntropyLog,
+} from '../src/index';
+import type { ISyntropyLog } from '../src/index';
+
+/**
+ * Tests for the `createSyntropyLog()` factory introduced in Phase 2A.
+ *
+ * The contract this suite locks in:
+ *
+ * - Each factory call returns a fresh instance with its own EventEmitter,
+ *   LifecycleManager, StatsCollector, and config.
+ * - The factory return type satisfies `ISyntropyLog`.
+ * - The global `syntropyLog` singleton is unaffected by factory instances
+ *   (and vice versa).
+ * - Independent instances can be initialized with different configs and
+ *   shut down independently; one instance's failures don't propagate.
+ */
+describe('createSyntropyLog factory', () => {
+  beforeEach(() => {
+    // Reset the singleton between tests so we don't accidentally observe leaked state.
+    SyntropyLog.resetInstance();
+  });
+
+  afterEach(async () => {
+    // Best-effort cleanup of the singleton if any test exercised it.
+    if (SyntropyLog.getInstance().getState() === 'READY') {
+      await SyntropyLog.getInstance().shutdown();
+    }
+    SyntropyLog.resetInstance();
+  });
+
+  describe('basic shape', () => {
+    it('returns an object that satisfies the ISyntropyLog interface', () => {
+      const sl: ISyntropyLog = createSyntropyLog();
+      expect(typeof sl.init).toBe('function');
+      expect(typeof sl.shutdown).toBe('function');
+      expect(typeof sl.getLogger).toBe('function');
+      expect(typeof sl.getStats).toBe('function');
+      expect(typeof sl.getState).toBe('function');
+      // EventEmitter contract
+      expect(typeof sl.on).toBe('function');
+      expect(typeof sl.emit).toBe('function');
+      expect(typeof sl.removeAllListeners).toBe('function');
+    });
+
+    it('starts in NOT_INITIALIZED state', () => {
+      const sl = createSyntropyLog();
+      expect(sl.getState()).toBe('NOT_INITIALIZED');
+    });
+
+    it('reports zeroed stats before init() resolves', () => {
+      const sl = createSyntropyLog();
+      const stats = sl.getStats();
+      expect(stats.state).toBe('NOT_INITIALIZED');
+      expect(stats.initializedAt).toBeNull();
+      expect(stats.uptimeMs).toBe(0);
+      expect(stats.failures.log).toBe(0);
+    });
+  });
+
+  describe('independence between instances', () => {
+    it('two factory instances are distinct objects with separate state', async () => {
+      const a = createSyntropyLog();
+      const b = createSyntropyLog();
+
+      expect(a).not.toBe(b);
+      expect(a.getState()).toBe('NOT_INITIALIZED');
+      expect(b.getState()).toBe('NOT_INITIALIZED');
+
+      await a.init({ logger: { serviceName: 'a', level: 'info' } });
+      expect(a.getState()).toBe('READY');
+      expect(b.getState()).toBe('NOT_INITIALIZED');
+
+      await a.shutdown();
+      expect(a.getState()).toBe('SHUTDOWN');
+      expect(b.getState()).toBe('NOT_INITIALIZED');
+    });
+
+    it('event listeners on one instance do not fire on another', async () => {
+      const a = createSyntropyLog();
+      const b = createSyntropyLog();
+
+      const onAReady = vi.fn();
+      const onBReady = vi.fn();
+      a.on('ready', onAReady);
+      b.on('ready', onBReady);
+
+      await a.init({ logger: { serviceName: 'a', level: 'info' } });
+
+      expect(onAReady).toHaveBeenCalledTimes(1);
+      expect(onBReady).not.toHaveBeenCalled();
+
+      await a.shutdown();
+    });
+
+    it('each instance accepts its own config — service names do not leak', async () => {
+      const a = createSyntropyLog();
+      const b = createSyntropyLog();
+
+      await a.init({ logger: { serviceName: 'tenant-a', level: 'info' } });
+      await b.init({ logger: { serviceName: 'tenant-b', level: 'warn' } });
+
+      expect(a.getConfig().logger?.serviceName).toBe('tenant-a');
+      expect(b.getConfig().logger?.serviceName).toBe('tenant-b');
+      expect(a.getConfig().logger?.level).toBe('info');
+      expect(b.getConfig().logger?.level).toBe('warn');
+
+      await a.shutdown();
+      await b.shutdown();
+    });
+
+    it('hook decoration tracks stats per instance', async () => {
+      const a = createSyntropyLog();
+      const b = createSyntropyLog();
+
+      await a.init({ logger: { serviceName: 'a', level: 'info' } });
+      await b.init({ logger: { serviceName: 'b', level: 'info' } });
+
+      // Fire the wrapped log-failure hook on `a` only.
+      a.getConfig().onLogFailure!(new Error('a-fault'), { msg: 'x' });
+      a.getConfig().onLogFailure!(new Error('a-fault'), { msg: 'x' });
+
+      expect(a.getStats().failures.log).toBe(2);
+      expect(b.getStats().failures.log).toBe(0);
+
+      await a.shutdown();
+      await b.shutdown();
+    });
+  });
+
+  describe('factory vs singleton independence', () => {
+    it('factory instance does not become the singleton', () => {
+      const factory = createSyntropyLog();
+      const singleton = SyntropyLog.getInstance();
+      expect(factory).not.toBe(singleton);
+      expect(factory).not.toBe(globalSyntropyLog);
+    });
+
+    it('initializing a factory instance does not affect the singleton state', async () => {
+      const factory = createSyntropyLog();
+      const singleton = SyntropyLog.getInstance();
+
+      await factory.init({ logger: { serviceName: 'factory', level: 'info' } });
+
+      expect(factory.getState()).toBe('READY');
+      expect(singleton.getState()).toBe('NOT_INITIALIZED');
+
+      await factory.shutdown();
+    });
+
+    it('shutting down a factory instance does not shut down the singleton', async () => {
+      const factory = createSyntropyLog();
+      const singleton = SyntropyLog.getInstance();
+
+      await singleton.init({
+        logger: { serviceName: 'singleton', level: 'info' },
+      });
+      await factory.init({ logger: { serviceName: 'factory', level: 'info' } });
+
+      await factory.shutdown();
+
+      expect(factory.getState()).toBe('SHUTDOWN');
+      expect(singleton.getState()).toBe('READY');
+
+      await singleton.shutdown();
+    });
+  });
+
+  describe('error isolation', () => {
+    it('user hooks on instance A are not called for events on instance B', async () => {
+      const userOnLogFailureA = vi.fn();
+      const userOnLogFailureB = vi.fn();
+
+      const a = createSyntropyLog();
+      const b = createSyntropyLog();
+
+      await a.init({
+        logger: { serviceName: 'a', level: 'info' },
+        onLogFailure: userOnLogFailureA,
+      });
+      await b.init({
+        logger: { serviceName: 'b', level: 'info' },
+        onLogFailure: userOnLogFailureB,
+      });
+
+      a.getConfig().onLogFailure!(new Error('a-only'), { msg: 'x' });
+
+      expect(userOnLogFailureA).toHaveBeenCalledTimes(1);
+      expect(userOnLogFailureB).not.toHaveBeenCalled();
+
+      await a.shutdown();
+      await b.shutdown();
+    });
+  });
+});


### PR DESCRIPTION
…erface

Adds a second supported entry point for obtaining a SyntropyLog instance:

- **`ISyntropyLog`** (new file) — the contract every instance fulfills. Extends EventEmitter and declares the full public surface (init, shutdown, getLogger, getStats, getMasker, etc.). `SyntropyLogStats` lives next to the interface (both re-exported from `SyntropyLog.ts` for path stability).
- **`SyntropyLog.create()`** — public static factory; new internal entry point. Constructor remains private.
- **`createSyntropyLog()`** — top-level factory function. Returns a fresh `ISyntropyLog` instance with its own LifecycleManager, EventEmitter, StatsCollector, hooks, and config. Does not touch the singleton.
- Global `syntropyLog` singleton kept as-is for backward compat.

Use cases for the factory:
- Multi-tenant apps where two tenants need different log routing or matrices.
- Parallel tests that need genuine isolation without `SyntropyLog.resetInstance()` / `_resetForTesting()` global state.
- Micro-frontends or any architecture that loads SyntropyLog from more than one module-graph root.

Phase 2A is **fully backwards-compatible**. No existing import, type, or behavior changes. The previously-published `SyntropyLogStats` import path (`from 'syntropylog'` and `from 'syntropylog/SyntropyLog'` via re-export) keeps working.

Test coverage: 11 new tests in `tests/factory.test.ts` covering interface shape, multi-instance independence (state, events, configs, stats), factory vs singleton isolation, and per-instance hook decoration. No regressions — all 120 baseline tests pass unchanged. tsc clean.

Docs: `docs/lifecycle.md` now opens with the two entry points and shows the multi-tenant pattern.

Phase 2B (next) will introduce the middleware sub-packages (Express, Fastify, NestJS) and the migration-from-pino doc, building on this factory.

## Summary
<!-- What does this PR do? -->

## Related Issue
<!-- Link to the issue this PR addresses, e.g. Fixes #123 -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Maintenance / Refactor

## Checklist
- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
