### PR TITLE
feat(nestjs): Phase 2C — NestJS sub-package (`syntropylog/nestjs`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Full middleware examples and correlation propagation: [docs/context.md](docs/con
 - **[Native addon (Rust)](docs/native-addon.md)** — concepts and runtime checks
 - **[Building the native addon from source](docs/building-native-addon.md)** — macOS / Windows / Linux
 - **[OpenTelemetry integration](docs/opentelemetry-integration.md)** — exporting logs to an OTLP collector
+- **[NestJS integration](docs/context.md#nestjs)** — `syntropylog/nestjs` module, `SyntropyNestLoggerService`, `@InjectLogger()`
 - **[Migrating from Pino](docs/migration-from-pino.md)** — practical side-by-side guide for teams switching
 - **[Benchmark report (throughput + memory)](docs/benchmark-memory-run.md)**
 - **[Examples repository](https://github.com/Syntropysoft/syntropylog-examples)** — runnable examples 01–17

--- a/docs/context.md
+++ b/docs/context.md
@@ -120,63 +120,95 @@ To **export logs** to an OTLP collector (so traces and logs land in the same bac
 
 ## NestJS
 
-NestJS routes through Express by default, so **use the same middleware pattern via `app.use(...)` in `bootstrap()` — not a NestJS `Interceptor`**. An interceptor runs *after* guards and pipes have already executed, which is too late for context to be available everywhere.
+The framework ships a NestJS sub-package — `syntropylog/nestjs` — that provides three things:
+
+- **`SyntropyLogModule`** — global Nest module wired to a SyntropyLog instance (singleton by default, override via `forRoot({ syntropyLog })`).
+- **`SyntropyNestLoggerService`** — `LoggerService` implementation that routes Nest's internal logs and every `new Logger('Foo').log(...)` call through SyntropyLog.
+- **`@InjectLogger()`** — parameter decorator that injects an `ILogger` pre-bound with the consumer's class name as `source` (uses Nest's `INQUIRER` + `Scope.TRANSIENT`).
+
+`@nestjs/common`, `@nestjs/core`, `reflect-metadata`, and `rxjs` are declared as **optional peer dependencies** — install them only if you import from `syntropylog/nestjs`.
+
+### Setup
 
 ```typescript
 // src/main.ts
 import { NestFactory } from '@nestjs/core';
+import { Module } from '@nestjs/common';
+import { syntropyLog, correlationIdMiddleware } from 'syntropylog';
+import {
+  SyntropyLogModule,
+  SyntropyNestLoggerService,
+} from 'syntropylog/nestjs';
 import { AppModule } from './app.module';
-import { syntropyLog } from 'syntropylog';
 
 async function bootstrap() {
   await syntropyLog.init({ /* … */ });
 
-  const app = await NestFactory.create(AppModule);
-  const { contextManager } = syntropyLog;
-
-  // AsyncLocalStorage scope wraps the whole request, including guards and pipes
-  app.use((req, res, next) => {
-    contextManager.run(async () => {
-      const cid =
-        (req.headers[contextManager.getCorrelationIdHeaderName().toLowerCase()] as string) ??
-        contextManager.getCorrelationId();
-      contextManager.set(contextManager.getCorrelationIdHeaderName(), cid);
-
-      // Wait until response is finished/closed before releasing the context
-      await new Promise<void>((resolve) => {
-        res.once('finish', resolve);
-        res.once('close', resolve);
-        next();
-      });
-    });
+  const app = await NestFactory.create(AppModule, {
+    bufferLogs: true,
+    logger: new SyntropyNestLoggerService(syntropyLog),
   });
+
+  // Express middleware (Nest routes through Express by default).
+  // Mount this BEFORE any controllers so guards/pipes observe the context.
+  app.use(correlationIdMiddleware());
 
   await app.listen(3000);
 }
 ```
 
-> **Tip — replace NestJS's built-in Logger with SyntropyLog.** Implement `LoggerService` once and pass it to `NestFactory.create`. Every `new Logger('Foo').log(...)` call in the codebase then routes through SyntropyLog without any other change.
->
-> ```typescript
-> import { LoggerService } from '@nestjs/common';
-> import { syntropyLog } from 'syntropylog';
->
-> class SyntropyNestLoggerService implements LoggerService {
->   private log = syntropyLog.getLogger('nest');
->   log(message: unknown, ctx?: string) { this.log.info({ nestContext: ctx }, String(message)); }
->   error(message: unknown, ctx?: string) { this.log.error({ nestContext: ctx }, String(message)); }
->   warn(message: unknown, ctx?: string) { this.log.warn({ nestContext: ctx }, String(message)); }
->   debug(message: unknown, ctx?: string) { this.log.debug({ nestContext: ctx }, String(message)); }
->   verbose(message: unknown, ctx?: string) { this.log.trace({ nestContext: ctx }, String(message)); }
->   fatal(message: unknown, ctx?: string) { this.log.fatal({ nestContext: ctx }, String(message)); }
-> }
->
-> const app = await NestFactory.create(AppModule, {
->   bufferLogs: true,
->   logger: new SyntropyNestLoggerService(),
-> });
-> ```
->
+The application module:
+
+```typescript
+// src/app.module.ts
+@Module({
+  imports: [SyntropyLogModule.forRoot()],
+  controllers: [/* … */],
+  providers: [/* … */],
+})
+export class AppModule {}
+```
+
+For multi-tenant apps, pass a factory-produced instance into `forRoot({ syntropyLog })` and into `SyntropyNestLoggerService(syntropyLog)`.
+
+### Using `@InjectLogger()` in services
+
+Each `@InjectLogger()` injection returns a fresh `ILogger` pre-bound with `.withSource(ConsumerClassName)`. The source name is read from NestJS's `INQUIRER` at injection time — no decorator argument required.
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import type { ILogger } from 'syntropylog';
+import { InjectLogger } from 'syntropylog/nestjs';
+
+@Injectable()
+export class PaymentService {
+  constructor(@InjectLogger() private readonly log: ILogger) {}
+
+  async charge(amount: number, userId: string) {
+    this.log.info({ amount, userId }, 'Charging card');
+    // → entry includes source: 'PaymentService' automatically.
+  }
+}
+```
+
+If you need a custom source name (e.g. a service whose class name doesn't match the desired log source), inject SyntropyLog itself and bind manually:
+
+```typescript
+import { Inject } from '@nestjs/common';
+import {
+  SYNTROPYLOG_INSTANCE_TOKEN,
+} from 'syntropylog/nestjs';
+import type { ISyntropyLog } from 'syntropylog';
+
+@Injectable()
+export class PaymentService {
+  private readonly log;
+  constructor(@Inject(SYNTROPYLOG_INSTANCE_TOKEN) sl: ISyntropyLog) {
+    this.log = sl.getLogger('payments').withSource('Stripe');
+  }
+}
+```
+
 > `bufferLogs: true` ensures startup logs are buffered until your custom logger is wired.
 
 ---

--- a/package.json
+++ b/package.json
@@ -112,6 +112,16 @@
         "types": "./dist/testing/SyntropyLogMock.d.ts",
         "default": "./dist/testing/SyntropyLogMock.cjs"
       }
+    },
+    "./nestjs": {
+      "import": {
+        "types": "./dist/nestjs/index.d.ts",
+        "default": "./dist/nestjs/index.mjs"
+      },
+      "require": {
+        "types": "./dist/nestjs/index.d.ts",
+        "default": "./dist/nestjs/index.cjs"
+      }
     }
   },
   "files": [
@@ -174,10 +184,25 @@
   "optionalDependencies": {
     "syntropylog-native": "workspace:*"
   },
+  "peerDependencies": {
+    "@nestjs/common": "^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^10.0.0 || ^11.0.0",
+    "reflect-metadata": "^0.1.13 || ^0.2.0",
+    "rxjs": "^7.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@nestjs/common": { "optional": true },
+    "@nestjs/core": { "optional": true },
+    "reflect-metadata": { "optional": true },
+    "rxjs": { "optional": true }
+  },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
     "@eslint/js": "^9.21.0",
     "@napi-rs/cli": "^2.18.0",
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
+    "@nestjs/testing": "^11.0.0",
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
@@ -194,8 +219,10 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "prettier": "^3.5.1",
+    "reflect-metadata": "^0.2.2",
     "rollup": "^4.34.8",
     "rollup-plugin-dts": "^6.1.1",
+    "rxjs": "^7.8.1",
     "tslib": "^2.8.1",
     "typescript": "^5.7.3",
     "typescript-eslint": "8.56.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,15 @@ importers:
       '@napi-rs/cli':
         specifier: ^2.18.0
         version: 2.18.4
+      '@nestjs/common':
+        specifier: ^11.0.0
+        version: 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.0.0
+        version: 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/testing':
+        specifier: ^11.0.0
+        version: 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
       '@rollup/plugin-commonjs':
         specifier: ^28.0.2
         version: 28.0.9(rollup@4.59.0)
@@ -75,12 +84,18 @@ importers:
       prettier:
         specifier: ^3.5.1
         version: 3.8.1
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
       rollup:
         specifier: ^4.34.8
         version: 4.59.0
       rollup-plugin-dts:
         specifier: ^6.1.1
         version: 6.3.0(rollup@4.59.0)(typescript@5.9.3)
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -108,7 +123,7 @@ importers:
         version: 9.14.0
       syntropylog:
         specifier: file:..
-        version: 'file:'
+        version: file:(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       winston:
         specifier: ^3.11.0
         version: 3.19.0
@@ -202,6 +217,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@changesets/apply-release-plan@7.1.0':
     resolution: {integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==}
@@ -516,6 +534,10 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@lukeed/csprng@1.1.0':
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
@@ -533,6 +555,50 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@nestjs/common@11.1.24':
+    resolution: {integrity: sha512-9zHxaDDM+oXW9As6UsP5yYB+UqczBmpeSCIFWdPEtEukMnZhxODG1BBjaUcdBB8Sc1uzojSJSJlp3yFp853t1g==}
+    peerDependencies:
+      class-transformer: '>=0.4.1'
+      class-validator: '>=0.13.2'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+
+  '@nestjs/core@11.1.24':
+    resolution: {integrity: sha512-K4bzT+lEdd0Hhcsw3jtk56QAW6s6skK3ViN7hIROSN0kUf4ROwWEAKopJID6yhPQxB45kDtP2wEcjzE8171J3g==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@nestjs/common': ^11.0.0
+      '@nestjs/microservices': ^11.0.0
+      '@nestjs/platform-express': ^11.0.0
+      '@nestjs/websockets': ^11.0.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      '@nestjs/microservices':
+        optional: true
+      '@nestjs/platform-express':
+        optional: true
+      '@nestjs/websockets':
+        optional: true
+
+  '@nestjs/testing@11.1.24':
+    resolution: {integrity: sha512-+4M4UAnhtprBQN0J2uI6IP0wDqhy9aH8XCMu5SO8oCi0oB04YXA4a4PAEkxmsPn7gHW4dj1u4GFteNQOWgvTJw==}
+    peerDependencies:
+      '@nestjs/common': ^11.0.0
+      '@nestjs/core': ^11.0.0
+      '@nestjs/microservices': ^11.0.0
+      '@nestjs/platform-express': ^11.0.0
+    peerDependenciesMeta:
+      '@nestjs/microservices':
+        optional: true
+      '@nestjs/platform-express':
+        optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -544,6 +610,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@nuxt/opencollective@0.4.1':
+    resolution: {integrity: sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==}
+    engines: {node: ^14.18.0 || >=16.10.0, npm: '>=5.10.0'}
+    hasBin: true
 
   '@oxc-project/types@0.132.0':
     resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
@@ -845,6 +916,13 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -1166,6 +1244,10 @@ packages:
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1372,6 +1454,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1390,6 +1475,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1503,6 +1592,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1588,6 +1680,10 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  iterare@1.2.1:
+    resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
+    engines: {node: '>=6'}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -1723,6 +1819,10 @@ packages:
   listr2@9.0.5:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
+
+  load-esm@1.0.3:
+    resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
+    engines: {node: '>=13.2.0'}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -1885,6 +1985,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -1970,6 +2073,9 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -2027,6 +2133,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -2145,6 +2254,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2160,6 +2273,20 @@ packages:
   'syntropylog@file:':
     resolution: {directory: '', type: directory}
     engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      '@nestjs/common':
+        optional: true
+      '@nestjs/core':
+        optional: true
+      reflect-metadata:
+        optional: true
+      rxjs:
+        optional: true
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -2199,6 +2326,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
   triple-beam@1.4.1:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
@@ -2232,6 +2363,14 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uid@2.0.2:
+    resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
+    engines: {node: '>=8'}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -2492,6 +2631,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@changesets/apply-release-plan@7.1.0':
     dependencies:
@@ -2829,6 +2970,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lukeed/csprng@1.1.0': {}
+
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -2854,6 +2997,36 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      file-type: 21.3.4
+      iterare: 1.2.1
+      load-esm: 1.0.3
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nuxt/opencollective': 0.4.1
+      fast-safe-stringify: 2.1.1
+      iterare: 1.2.1
+      path-to-regexp: 8.4.2
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+
+  '@nestjs/testing@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+    dependencies:
+      '@nestjs/common': 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      tslib: 2.8.1
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2865,6 +3038,10 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@nuxt/opencollective@0.4.1':
+    dependencies:
+      consola: 3.4.2
 
   '@oxc-project/types@0.132.0': {}
 
@@ -3049,6 +3226,15 @@ snapshots:
       text-hex: 1.0.0
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -3414,6 +3600,8 @@ snapshots:
 
   commondir@1.0.1: {}
 
+  consola@3.4.2: {}
+
   convert-source-map@2.0.0: {}
 
   cosmiconfig@7.1.0:
@@ -3653,6 +3841,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-safe-stringify@2.1.1: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -3666,6 +3856,15 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   fill-range@7.1.1:
     dependencies:
@@ -3779,6 +3978,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -3852,6 +4053,8 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  iterare@1.2.1: {}
 
   js-tokens@10.0.0: {}
 
@@ -3961,6 +4164,8 @@ snapshots:
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
+
+  load-esm@1.0.3: {}
 
   locate-path@5.0.0:
     dependencies:
@@ -4122,6 +4327,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-to-regexp@8.4.2: {}
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
@@ -4200,6 +4407,8 @@ snapshots:
       picomatch: 4.0.4
 
   real-require@0.2.0: {}
+
+  reflect-metadata@0.2.2: {}
 
   require-directory@2.1.1: {}
 
@@ -4294,6 +4503,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-buffer@5.2.1: {}
 
@@ -4394,6 +4607,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -4404,8 +4621,12 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
-  'syntropylog@file:':
+  syntropylog@file:(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2):
     optionalDependencies:
+      '@nestjs/common': 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
       syntropylog-native: link:syntropylog-native
 
   term-size@2.2.1: {}
@@ -4444,6 +4665,12 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   triple-beam@1.4.1: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
@@ -4475,6 +4702,12 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  uid@2.0.2:
+    dependencies:
+      '@lukeed/csprng': 1.1.0
+
+  uint8array-extras@1.5.0: {}
 
   undici-types@6.21.0: {}
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -114,10 +114,25 @@ export default [
     external: [...external, 'vitest'],
   }),
 
+  // NestJS sub-package — Nest deps stay external (peer-dep, optional).
+  createEntryConfig('src/nestjs/index.ts', './dist/nestjs/index', {
+    external: [
+      ...external,
+      '@nestjs/common',
+      '@nestjs/core',
+      'reflect-metadata',
+      'rxjs',
+    ],
+  }),
+
   // --- Type Declaration Bundles (.d.ts) ---
   createDtsConfig('dist/types/type-exports.d.ts', 'dist/index.d.ts'),
   createDtsConfig(
     'dist/types/testing/index.d.ts',
     'dist/testing/index.d.ts',
+  ),
+  createDtsConfig(
+    'dist/types/nestjs/index.d.ts',
+    'dist/nestjs/index.d.ts',
   ),
 ];

--- a/src/nestjs/InjectLogger.ts
+++ b/src/nestjs/InjectLogger.ts
@@ -1,0 +1,39 @@
+/**
+ * @file src/nestjs/InjectLogger.ts
+ * @description Parameter decorator that injects a SyntropyLog `ILogger`
+ * pre-bound with the consumer's class name as its `source`.
+ *
+ * Usage:
+ *
+ * ```typescript
+ * @Injectable()
+ * export class PaymentService {
+ *   constructor(@InjectLogger() private readonly log: ILogger) {}
+ *
+ *   charge() {
+ *     this.log.info({ amount: 1500 }, 'Charging');
+ *     // → entry includes `source: 'PaymentService'` automatically.
+ *   }
+ * }
+ * ```
+ *
+ * The decorator is just an alias for `@Inject(SYNTROPYLOG_LOGGER_TOKEN)`.
+ * The provider behind that token is registered with `Scope.TRANSIENT` and
+ * uses NestJS's `INQUIRER` to read the *consumer's* class name at injection
+ * time, then returns `syntropyLog.getLogger(...).withSource(className)`.
+ *
+ * If you need a logger bound to a *custom* source string instead of the
+ * class name, inject the SyntropyLog instance directly and call
+ * `getLogger().withSource(...)` yourself.
+ */
+
+import { Inject } from '@nestjs/common';
+import { SYNTROPYLOG_LOGGER_TOKEN } from './tokens';
+
+/**
+ * Inject a SyntropyLog `ILogger` pre-bound with the consumer's class name
+ * as its `source` field.
+ */
+export function InjectLogger(): ParameterDecorator {
+  return Inject(SYNTROPYLOG_LOGGER_TOKEN);
+}

--- a/src/nestjs/SyntropyLogModule.ts
+++ b/src/nestjs/SyntropyLogModule.ts
@@ -1,0 +1,129 @@
+/**
+ * @file src/nestjs/SyntropyLogModule.ts
+ * @description The NestJS module that wires SyntropyLog into an app.
+ *
+ * Registers three things:
+ *   1. The `ISyntropyLog` instance (singleton by default, override via options).
+ *   2. {@link SyntropyNestLoggerService} as a Nest `LoggerService` so
+ *      `new Logger('Foo').log(...)` calls route through SyntropyLog.
+ *   3. A `TRANSIENT`-scope `ILogger` provider keyed on
+ *      {@link SYNTROPYLOG_LOGGER_TOKEN}, used by `@InjectLogger()`. The
+ *      provider uses `INQUIRER` so each consumer receives a logger pre-bound
+ *      with its own class name as `source`.
+ *
+ * The module is marked `global` so the providers are visible everywhere
+ * without re-importing in every feature module.
+ *
+ * ```typescript
+ * @Module({
+ *   imports: [SyntropyLogModule.forRoot()],
+ *   controllers: [AppController],
+ *   providers: [PaymentService],
+ * })
+ * export class AppModule {}
+ * ```
+ */
+
+import {
+  Module,
+  Scope,
+  type DynamicModule,
+  type Provider,
+} from '@nestjs/common';
+import { INQUIRER } from '@nestjs/core';
+import type { ILogger } from '../logger';
+import type { ISyntropyLog } from '../ISyntropyLog';
+import { syntropyLog as defaultSyntropyLog } from '../SyntropyLog';
+import { SYNTROPYLOG_INSTANCE_TOKEN, SYNTROPYLOG_LOGGER_TOKEN } from './tokens';
+import {
+  SyntropyNestLoggerService,
+  type SyntropyNestLoggerServiceOptions,
+} from './SyntropyNestLoggerService';
+
+/** Options accepted by {@link SyntropyLogModule.forRoot}. */
+export interface SyntropyLogModuleOptions extends SyntropyNestLoggerServiceOptions {
+  /**
+   * The SyntropyLog instance to use for all NestJS-issued logs and for the
+   * `@InjectLogger()` provider. Defaults to the global singleton.
+   *
+   * Pass an instance from {@link createSyntropyLog} for multi-tenant apps
+   * or for isolated test setups.
+   */
+  syntropyLog?: ISyntropyLog;
+}
+
+/**
+ * Reads the class name of the consumer requesting an `@InjectLogger()`
+ * injection. Falls back to a deterministic default when the inquirer is
+ * unavailable (rare — happens in some edge cases of dynamic resolution).
+ */
+function sourceFromInquirer(inquirer: unknown): string {
+  if (
+    inquirer &&
+    typeof inquirer === 'object' &&
+    'constructor' in inquirer &&
+    typeof (inquirer as { constructor: { name?: unknown } }).constructor
+      .name === 'string'
+  ) {
+    return (inquirer as { constructor: { name: string } }).constructor.name;
+  }
+  return 'unknown';
+}
+
+@Module({})
+export class SyntropyLogModule {
+  /**
+   * Configures the module synchronously with a known SyntropyLog instance.
+   *
+   * @example
+   * ```typescript
+   * // Default — uses the global singleton:
+   * SyntropyLogModule.forRoot()
+   *
+   * // Multi-tenant — uses a factory-produced instance:
+   * SyntropyLogModule.forRoot({ syntropyLog: tenantLogging })
+   *
+   * // Custom Nest-internal log routing:
+   * SyntropyLogModule.forRoot({ loggerName: 'nest-internal', defaultContext: 'platform' })
+   * ```
+   */
+  static forRoot(options: SyntropyLogModuleOptions = {}): DynamicModule {
+    const sl = options.syntropyLog ?? defaultSyntropyLog;
+
+    const instanceProvider: Provider = {
+      provide: SYNTROPYLOG_INSTANCE_TOKEN,
+      useValue: sl,
+    };
+
+    const serviceProvider: Provider = {
+      provide: SyntropyNestLoggerService,
+      inject: [SYNTROPYLOG_INSTANCE_TOKEN],
+      useFactory: (syntropyLog: ISyntropyLog) =>
+        new SyntropyNestLoggerService(syntropyLog, {
+          defaultContext: options.defaultContext,
+          loggerName: options.loggerName,
+        }),
+    };
+
+    const transientLoggerProvider: Provider = {
+      provide: SYNTROPYLOG_LOGGER_TOKEN,
+      scope: Scope.TRANSIENT,
+      inject: [SYNTROPYLOG_INSTANCE_TOKEN, { token: INQUIRER, optional: true }],
+      useFactory: (syntropyLog: ISyntropyLog, inquirer: unknown): ILogger => {
+        const source = sourceFromInquirer(inquirer);
+        return syntropyLog.getLogger(source).withSource(source);
+      },
+    };
+
+    return {
+      module: SyntropyLogModule,
+      global: true,
+      providers: [instanceProvider, serviceProvider, transientLoggerProvider],
+      exports: [
+        SYNTROPYLOG_INSTANCE_TOKEN,
+        SYNTROPYLOG_LOGGER_TOKEN,
+        SyntropyNestLoggerService,
+      ],
+    };
+  }
+}

--- a/src/nestjs/SyntropyNestLoggerService.ts
+++ b/src/nestjs/SyntropyNestLoggerService.ts
@@ -1,0 +1,197 @@
+/**
+ * @file src/nestjs/SyntropyNestLoggerService.ts
+ * @description Implementation of NestJS's `LoggerService` interface that
+ * routes every call (`log`, `error`, `warn`, `debug`, `verbose`, `fatal`)
+ * into a SyntropyLog instance. Install it via
+ * `NestFactory.create(App, { logger: new SyntropyNestLoggerService(sl) })`
+ * or through `SyntropyLogModule.forRoot({...})` and Nest will use it for
+ * its own internal logs **and** for every `new Logger('Foo').log(...)` in
+ * application code.
+ *
+ * The implementation mirrors the production pattern from
+ * `echeq-sandbox-nestjs/src/common/syntropy-nest-logger.service.ts`, with
+ * two improvements:
+ *   1. Accepts an injected `ISyntropyLog` instance (instead of hardcoding
+ *      the singleton). Multi-tenant or test apps can pass the instance
+ *      they want.
+ *   2. The default-context for the `nestContext` metadata is configurable.
+ */
+
+import {
+  Inject,
+  Injectable,
+  Optional,
+  type LoggerService,
+  type LogLevel,
+} from '@nestjs/common';
+import type { ISyntropyLog } from '../ISyntropyLog';
+import { syntropyLog as defaultSyntropyLog } from '../SyntropyLog';
+import { SYNTROPYLOG_INSTANCE_TOKEN } from './tokens';
+
+/** SyntropyLog method names that map 1:1 from Nest levels. */
+const SL_METHODS = new Set([
+  'info',
+  'warn',
+  'error',
+  'debug',
+  'trace',
+  'fatal',
+] as const);
+
+type SLMethodName = 'info' | 'warn' | 'error' | 'debug' | 'trace' | 'fatal';
+
+/**
+ * `JSON.stringify(new Error('x'))` returns `'{}'` because Error does not
+ * expose `message` / `stack` as enumerable properties. We extract them
+ * explicitly so the log line carries the actual error info — not `{"value":{}}`.
+ */
+function serializeForLog(value: unknown): unknown {
+  if (value instanceof Error) {
+    const cause = (value as Error & { cause?: unknown }).cause;
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      ...(cause !== undefined && { cause: serializeForLog(cause) }),
+    };
+  }
+  return value;
+}
+
+/**
+ * Builds the final message string Nest will see. Nest passes the primary
+ * message plus arbitrary `optionalParams`; some are context strings (short,
+ * no newlines), others are extras (stack traces, structured data). We pack
+ * the non-context extras into a JSON value alongside the primary message.
+ */
+function toMessageString(message: unknown, optionalParams: unknown[]): string {
+  if (typeof message === 'string') return message;
+
+  const serialized = serializeForLog(message);
+  const extras = optionalParams
+    .filter((p) => typeof p !== 'string' || !String(p).includes('\n'))
+    .map((p) => serializeForLog(p));
+  try {
+    return JSON.stringify(
+      extras.length ? { value: serialized, extra: extras } : serialized
+    );
+  } catch {
+    return String(message);
+  }
+}
+
+/**
+ * Nest's `new Logger('PaymentService').log('msg')` passes `'PaymentService'`
+ * as the last optional param. We pluck the first short string we see — that
+ * matches Nest's convention and ignores stack traces (which contain newlines).
+ */
+function pickNestContext(optionalParams: unknown[]): string | undefined {
+  for (const p of optionalParams) {
+    if (typeof p === 'string' && !p.includes('\n')) return p;
+  }
+  return undefined;
+}
+
+/** Options accepted by the service constructor (and forwarded by the module). */
+export interface SyntropyNestLoggerServiceOptions {
+  /**
+   * Default value for the `nestContext` metadata when Nest does not pass a
+   * context string (rare; some internal logs lack it). Defaults to `'nest'`.
+   */
+  defaultContext?: string;
+  /**
+   * Name of the SyntropyLog logger used to emit Nest messages. Defaults to
+   * `'nest'`. Useful when you route Nest's own logs to a different transport
+   * than your application code.
+   */
+  loggerName?: string;
+}
+
+/**
+ * NestJS `LoggerService` implementation that delegates to SyntropyLog.
+ *
+ * Once registered via `SyntropyLogModule.forRoot()` (or passed directly to
+ * `NestFactory.create`), every `new Logger('Module').log('msg')` in your
+ * codebase routes through SyntropyLog's masking/serialization/matrix
+ * pipeline — including Nest's own startup banner.
+ */
+@Injectable()
+export class SyntropyNestLoggerService implements LoggerService {
+  private readonly defaultContext: string;
+  private readonly loggerName: string;
+
+  constructor(
+    @Optional() @Inject(SYNTROPYLOG_INSTANCE_TOKEN) syntropyLog?: ISyntropyLog,
+    options: SyntropyNestLoggerServiceOptions = {}
+  ) {
+    this.sl = syntropyLog ?? defaultSyntropyLog;
+    this.defaultContext = options.defaultContext ?? 'nest';
+    this.loggerName = options.loggerName ?? 'nest';
+  }
+
+  private readonly sl: ISyntropyLog;
+
+  private emit(
+    level: 'info' | 'warn' | 'error' | 'debug' | 'verbose' | 'fatal',
+    message: unknown,
+    optionalParams: unknown[]
+  ): void {
+    const log = this.sl.getLogger(this.loggerName);
+    const nestContext = pickNestContext(optionalParams) ?? this.defaultContext;
+    const msg = toMessageString(message, optionalParams);
+    const meta = { type: 'app', nestContext };
+
+    // Nest's `verbose` maps to SyntropyLog's `trace`. Any unknown level falls back to `info`.
+    const slLevel: SLMethodName =
+      level === 'verbose'
+        ? 'trace'
+        : SL_METHODS.has(level as SLMethodName)
+          ? (level as SLMethodName)
+          : 'info';
+
+    const fn = (
+      log as unknown as Record<SLMethodName, (m: object, s: string) => void>
+    )[slLevel];
+
+    if (typeof fn === 'function') {
+      fn.call(log, meta, msg);
+    } else {
+      log.info(meta, msg);
+    }
+  }
+
+  log(message: unknown, ...optionalParams: unknown[]): void {
+    this.emit('info', message, optionalParams);
+  }
+
+  error(message: unknown, ...optionalParams: unknown[]): void {
+    this.emit('error', message, optionalParams);
+  }
+
+  warn(message: unknown, ...optionalParams: unknown[]): void {
+    this.emit('warn', message, optionalParams);
+  }
+
+  debug(message: unknown, ...optionalParams: unknown[]): void {
+    this.emit('debug', message, optionalParams);
+  }
+
+  verbose(message: unknown, ...optionalParams: unknown[]): void {
+    this.emit('verbose', message, optionalParams);
+  }
+
+  fatal(message: unknown, ...optionalParams: unknown[]): void {
+    this.emit('fatal', message, optionalParams);
+  }
+
+  /**
+   * Nest sometimes calls `setLogLevels` to adjust verbosity at runtime. We
+   * accept it but do not act on it — SyntropyLog levels are configured at
+   * `init()` and (in some surfaces) via `logger.setLevel()`. Honoring Nest's
+   * call here would override your declarative level config without the
+   * config knowing.
+   */
+  setLogLevels(_levels: LogLevel[]): void {
+    // intentional no-op
+  }
+}

--- a/src/nestjs/index.ts
+++ b/src/nestjs/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @file src/nestjs/index.ts
+ * @description Public surface of the `syntropylog/nestjs` sub-package.
+ *
+ * NestJS is an optional peer dependency — install it (and `@nestjs/core`,
+ * `reflect-metadata`, `rxjs`) only if you import from this entry point.
+ */
+
+export {
+  SyntropyNestLoggerService,
+  type SyntropyNestLoggerServiceOptions,
+} from './SyntropyNestLoggerService';
+
+export {
+  SyntropyLogModule,
+  type SyntropyLogModuleOptions,
+} from './SyntropyLogModule';
+
+export { InjectLogger } from './InjectLogger';
+
+export { SYNTROPYLOG_INSTANCE_TOKEN, SYNTROPYLOG_LOGGER_TOKEN } from './tokens';

--- a/src/nestjs/tokens.ts
+++ b/src/nestjs/tokens.ts
@@ -1,0 +1,17 @@
+/**
+ * @file src/nestjs/tokens.ts
+ * @description Injection tokens shared across the NestJS sub-package.
+ *
+ * Symbol-based tokens to avoid accidental string collisions and to make the
+ * dependency surface explicit in IDE search.
+ */
+
+/** Injection token for the configured `ISyntropyLog` instance. */
+export const SYNTROPYLOG_INSTANCE_TOKEN = Symbol.for('SyntropyLog.Instance');
+
+/**
+ * Injection token for a per-consumer `ILogger`. The provider is registered
+ * as `Scope.TRANSIENT` and uses `INQUIRER` to derive the source name from
+ * the class that requested the injection — see `@InjectLogger`.
+ */
+export const SYNTROPYLOG_LOGGER_TOKEN = Symbol.for('SyntropyLog.Logger');

--- a/tests/nestjs/nestjs-integration.test.ts
+++ b/tests/nestjs/nestjs-integration.test.ts
@@ -1,0 +1,275 @@
+import './setup';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Injectable, Logger, Module } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import {
+  createSyntropyLog,
+  SpyTransport,
+  type ILogger,
+  type ISyntropyLog,
+} from '../../src/index';
+import {
+  SyntropyLogModule,
+  SyntropyNestLoggerService,
+  InjectLogger,
+} from '../../src/nestjs/index';
+
+/**
+ * End-to-end tests for the NestJS sub-package. Each test spins up a real
+ * NestJS testing module configured with SyntropyLogModule.forRoot(...) and
+ * a SpyTransport so we can assert against what actually got logged.
+ *
+ * Per testing principle: every assertion must catch a regression that
+ * matters. We do NOT assert that providers exist — we exercise them and
+ * assert on the captured log entries.
+ */
+describe('@syntropylog/nestjs — integration', () => {
+  let sl: ISyntropyLog;
+  let spy: SpyTransport;
+
+  beforeEach(async () => {
+    // The SpyTransport defaults to `level: 'info'`, which would filter trace/debug
+    // before the entry reaches us. Configure it to capture everything so the
+    // verbose→trace mapping test can observe what the service emitted.
+    spy = new SpyTransport({ level: 'trace' });
+    sl = createSyntropyLog();
+    await sl.init({
+      logger: {
+        serviceName: 'nestjs-test',
+        level: 'trace',
+        transports: [spy],
+      },
+    });
+  });
+
+  afterEach(async () => {
+    if (sl.getState() === 'READY') await sl.shutdown();
+  });
+
+  describe('SyntropyNestLoggerService as NestJS LoggerService', () => {
+    it('routes a Nest service.log(msg) call through SyntropyLog with the right level and nestContext', async () => {
+      const moduleRef: TestingModule = await Test.createTestingModule({
+        imports: [SyntropyLogModule.forRoot({ syntropyLog: sl })],
+      }).compile();
+
+      const nestLogger = moduleRef.get(SyntropyNestLoggerService);
+      spy.clear(); // drop the framework's init banner
+
+      nestLogger.log('order processed', 'OrderService');
+
+      const entry = spy.getLastEntry() as unknown as {
+        level: string;
+        message: string;
+        nestContext: string;
+      };
+      expect(entry.level).toBe('info');
+      expect(entry.message).toBe('order processed');
+      expect(entry.nestContext).toBe('OrderService');
+    });
+
+    it('maps Nest verbose → SyntropyLog trace', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [SyntropyLogModule.forRoot({ syntropyLog: sl })],
+      }).compile();
+
+      const nestLogger = moduleRef.get(SyntropyNestLoggerService);
+      spy.clear();
+
+      nestLogger.verbose('detailed trace info', 'AppCtx');
+
+      const entry = spy.getLastEntry();
+      expect(entry?.level).toBe('trace');
+      expect(entry?.message).toBe('detailed trace info');
+    });
+
+    it('error(): preserves Error message and stack instead of {} (the Error-serialization regression guard)', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [SyntropyLogModule.forRoot({ syntropyLog: sl })],
+      }).compile();
+
+      const nestLogger = moduleRef.get(SyntropyNestLoggerService);
+      spy.clear();
+
+      const err = new Error('payment declined');
+      nestLogger.error(err, 'PaymentService');
+
+      const entry = spy.getLastEntry();
+      expect(entry?.level).toBe('error');
+      // Message must contain the actual error info, not "{\"value\":{}}".
+      const serialized = String(entry?.message);
+      expect(serialized).toContain('payment declined');
+      expect(serialized).not.toBe('{}');
+    });
+
+    it('honors loggerName option — Nest logs route through the named SyntropyLog logger', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          SyntropyLogModule.forRoot({
+            syntropyLog: sl,
+            loggerName: 'nest-internal',
+          }),
+        ],
+      }).compile();
+
+      const nestLogger = moduleRef.get(SyntropyNestLoggerService);
+      spy.clear();
+
+      nestLogger.log('platform message', 'AppCtx');
+
+      // The SyntropyLog logger name becomes the entry's `service` field via the framework.
+      const entry = spy.getLastEntry() as unknown as { service: string };
+      expect(entry.service).toBe('nest-internal');
+    });
+  });
+
+  describe('@InjectLogger() with INQUIRER', () => {
+    it('returns a logger pre-bound with the injecting class name as source', async () => {
+      @Injectable()
+      class PaymentService {
+        constructor(@InjectLogger() readonly log: ILogger) {}
+      }
+
+      @Module({
+        imports: [SyntropyLogModule.forRoot({ syntropyLog: sl })],
+        providers: [PaymentService],
+        exports: [PaymentService],
+      })
+      class TestModule {}
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [TestModule],
+      }).compile();
+
+      const svc = await moduleRef.resolve(PaymentService);
+      spy.clear();
+
+      svc.log.info({ orderId: 'ord_1' }, 'charged');
+
+      const entry = spy.getLastEntry() as unknown as {
+        message: string;
+        source: string;
+        orderId: string;
+      };
+      expect(entry.message).toBe('charged');
+      expect(entry.source).toBe('PaymentService');
+      expect(entry.orderId).toBe('ord_1');
+    });
+
+    it('different services receive different pre-bound loggers (transient scope)', async () => {
+      @Injectable()
+      class A {
+        constructor(@InjectLogger() readonly log: ILogger) {}
+      }
+      @Injectable()
+      class B {
+        constructor(@InjectLogger() readonly log: ILogger) {}
+      }
+
+      @Module({
+        imports: [SyntropyLogModule.forRoot({ syntropyLog: sl })],
+        providers: [A, B],
+        exports: [A, B],
+      })
+      class TestModule {}
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [TestModule],
+      }).compile();
+
+      const a = await moduleRef.resolve(A);
+      const b = await moduleRef.resolve(B);
+      spy.clear();
+
+      a.log.info('from A');
+      b.log.info('from B');
+
+      const entries = spy.getEntries();
+      const sources = entries.map(
+        (e) => (e as unknown as { source: string }).source
+      );
+      expect(sources).toContain('A');
+      expect(sources).toContain('B');
+      // No leak across consumers:
+      const fromA = entries.find((e) => e.message === 'from A') as unknown as {
+        source: string;
+      };
+      const fromB = entries.find((e) => e.message === 'from B') as unknown as {
+        source: string;
+      };
+      expect(fromA.source).toBe('A');
+      expect(fromB.source).toBe('B');
+    });
+  });
+
+  describe('forRoot({ syntropyLog }) — instance isolation', () => {
+    it('two NestJS apps with different SyntropyLog instances do not cross-talk', async () => {
+      const spyA = new SpyTransport();
+      const spyB = new SpyTransport();
+      const slA = createSyntropyLog();
+      const slB = createSyntropyLog();
+      await slA.init({
+        logger: { serviceName: 'app-a', level: 'info', transports: [spyA] },
+      });
+      await slB.init({
+        logger: { serviceName: 'app-b', level: 'info', transports: [spyB] },
+      });
+
+      const modA = await Test.createTestingModule({
+        imports: [SyntropyLogModule.forRoot({ syntropyLog: slA })],
+      }).compile();
+      const modB = await Test.createTestingModule({
+        imports: [SyntropyLogModule.forRoot({ syntropyLog: slB })],
+      }).compile();
+
+      const loggerA = modA.get(SyntropyNestLoggerService);
+      const loggerB = modB.get(SyntropyNestLoggerService);
+      spyA.clear();
+      spyB.clear();
+
+      loggerA.log('hello from A', 'AppA');
+      loggerB.log('hello from B', 'AppB');
+
+      const messagesA = spyA.getEntries().map((e) => e.message);
+      const messagesB = spyB.getEntries().map((e) => e.message);
+
+      expect(messagesA).toContain('hello from A');
+      expect(messagesA).not.toContain('hello from B');
+      expect(messagesB).toContain('hello from B');
+      expect(messagesB).not.toContain('hello from A');
+
+      await slA.shutdown();
+      await slB.shutdown();
+    });
+  });
+
+  describe('integration: Nest Logger() class routed through the service', () => {
+    it('new Logger("ModName").log("msg") routes through SyntropyLog when the service is registered as the app-level logger', async () => {
+      // The shipped service is installable as Nest's app-level LoggerService:
+      // `NestFactory.create(App, { logger: serviceInstance })`. We simulate
+      // that here by registering the service against Logger's static API.
+      const moduleRef = await Test.createTestingModule({
+        imports: [SyntropyLogModule.forRoot({ syntropyLog: sl })],
+      }).compile();
+
+      const nestLogger = moduleRef.get(SyntropyNestLoggerService);
+      Logger.overrideLogger(nestLogger);
+      spy.clear();
+
+      // Real Nest usage pattern — somewhere in a service:
+      const log = new Logger('CheckoutController');
+      log.warn('cart abandoned');
+
+      const entry = spy.getLastEntry() as unknown as {
+        level: string;
+        message: string;
+        nestContext: string;
+      };
+      expect(entry.level).toBe('warn');
+      expect(entry.message).toBe('cart abandoned');
+      expect(entry.nestContext).toBe('CheckoutController');
+
+      // Restore default for other tests.
+      Logger.overrideLogger(undefined as never);
+    });
+  });
+});

--- a/tests/nestjs/setup.ts
+++ b/tests/nestjs/setup.ts
@@ -1,0 +1,10 @@
+/**
+ * @file tests/nestjs/setup.ts
+ * @description NestJS decorators require `reflect-metadata` loaded once at
+ * process start. Vitest does not auto-import it; we import it here so any
+ * test in tests/nestjs/ gets the metadata machinery configured.
+ *
+ * Wire-up: imported at the top of each NestJS test file.
+ */
+
+import 'reflect-metadata';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,6 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   }
-} 
+}


### PR DESCRIPTION
Closes the remaining Phase 2 item from the roadmap: a first-class NestJS adapter that lets a team drop SyntropyLog into a Nest app with one module import and one custom logger registration.

What ships under `syntropylog/nestjs`:

- **`SyntropyNestLoggerService`** — `LoggerService` implementation. Routes every `log`/`error`/`warn`/`debug`/`verbose`/`fatal` call through SyntropyLog. Pass it to `NestFactory.create(App, { logger })` and every `new Logger('Foo').log(...)` in the codebase routes through the framework — including Nest's startup banner. Maps Nest `verbose` → SL `trace`. Preserves Error.message / Error.stack (Errors stringify to `'{}'` by default — this matches the production echeq-sandbox pattern). Accepts an injected `ISyntropyLog` (defaults to singleton); supports custom `loggerName` and `defaultContext` options.

- **`SyntropyLogModule.forRoot({ syntropyLog?, loggerName?, defaultContext? })`** — Nest `@Module` (global) that registers three providers: the configured `ISyntropyLog` instance, the `SyntropyNestLoggerService`, and a `Scope.TRANSIENT` `ILogger` provider keyed on `SYNTROPYLOG_LOGGER_TOKEN`.

- **`@InjectLogger()`** — parameter decorator (alias for `@Inject(SYNTROPYLOG_LOGGER_TOKEN)`). The transient provider uses Nest's `INQUIRER` to read the consumer's class name and returns `syntropyLog.getLogger(className).withSource(className)`. Each consumer gets its own logger pre-bound to its own source — no decorator argument required.

- **Symbol-keyed injection tokens**: `SYNTROPYLOG_INSTANCE_TOKEN`, `SYNTROPYLOG_LOGGER_TOKEN`. Exported for users who want to construct providers around them directly.

Subpath export wiring:
- `package.json` `exports['./nestjs']` → `dist/nestjs/index.{cjs,mjs,d.ts}`.
- `@nestjs/common`, `@nestjs/core`, `reflect-metadata`, `rxjs` declared as **optional peer dependencies** so users without NestJS in their tree get no warnings.
- `rollup.config.mjs` builds the new entry; Nest deps stay external.
- `tsconfig.base.json` gains `experimentalDecorators` + `emitDecoratorMetadata` required by Nest's decorator runtime.

Behavioral tests (`tests/nestjs/nestjs-integration.test.ts`) mount real `@nestjs/testing` modules and assert against entries captured by a `SpyTransport`:
- `SyntropyNestLoggerService.log()` produces the right level, message, and nestContext.
- Nest `verbose` actually maps to SL `trace` (caught a real bug here — the spy's default `level: 'info'` was filtering out trace; the test now configures it to capture all levels).
- `Error` instances preserve `message` (the `JSON.stringify(new Error) === '{}'` regression guard from the production pattern).
- `@InjectLogger()` actually returns class-name-bound loggers, and different services receive distinct instances (transient scope).
- Two NestJS apps configured with two different SyntropyLog instances don't cross-talk.
- `Logger.overrideLogger(service)` followed by `new Logger('Foo').warn(...)` routes through SL — the canonical Nest usage pattern.

Docs:
- `docs/context.md` NestJS section rewritten around the shipped module + decorator. Replaces the previous inline boilerplate.
- README's Documentation list links to the NestJS section.

This closes Phase 2. Next: Phase 3 (DurableAdapterTransport + audit-grade adapters + prototype-pollution guard).

## Summary
<!-- What does this PR do? -->

## Related Issue
<!-- Link to the issue this PR addresses, e.g. Fixes #123 -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Maintenance / Refactor

## Checklist
- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
