### PR TITLE
ci(native): pin @napi-rs/cli@2.18.4 as a direct dep of syntropylog-na…

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,7 +140,11 @@ importers:
         specifier: file:../syntropylog-native
         version: link:../syntropylog-native
 
-  syntropylog-native: {}
+  syntropylog-native:
+    devDependencies:
+      '@napi-rs/cli':
+        specifier: 2.18.4
+        version: 2.18.4
 
 packages:
 

--- a/syntropylog-native/package.json
+++ b/syntropylog-native/package.json
@@ -33,7 +33,9 @@
     "build:debug": "napi build && node scripts/patch-index-no-shell.js",
     "test": "node test-node.mjs"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@napi-rs/cli": "2.18.4"
+  },
   "files": [
     "index.js",
     "index.mjs",


### PR DESCRIPTION
…tive

CI was resolving a napi 3.x via 'pnpm exec napi' from the native package (3.x dropped --zig in favor of --cross-compile), so the cross-compile step failed with 'Unsupported option --zig' — even though the root pins @napi-rs/cli@2.18.4 (which has --zig). Declaring it as a direct devDependency of syntropylog-native makes 'pnpm exec napi' resolve 2.18.4 deterministically in CI and locally. Verified locally: resolves 2.18.4 (--zig present) and cross-compiles musl to a valid ELF.

## Summary
<!-- What does this PR do? -->

## Related Issue
<!-- Link to the issue this PR addresses, e.g. Fixes #123 -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Maintenance / Refactor

## Checklist
- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
