### PR TITLE
fix(release): unblock the changesets version commit on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,3 +150,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # The version-bump commit must not run husky hooks: CI already gates
+          # tests, and the pre-commit suite ran here before any dist existed
+          # (broke the changesets commit on 2026-07-09).
+          HUSKY: 0

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,6 +1,15 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // The nestjs subpath imports from bare 'syntropylog' (KNOWN-ISSUES #1 fix).
+      // Tests must resolve it to src, never to a (possibly missing/stale) dist —
+      // the Release job runs the pre-commit suite before any build exists.
+      syntropylog: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+    },
+  },
   test: {
     globals: true, // Enable global test functions like describe, it, beforeEach, etc.
     environment: 'node', // Or 'jsdom' if you need to simulate a browser


### PR DESCRIPTION
Two independent guards for the failure seen on the first 1.3.0 Release run:

- vitest resolve alias: bare 'syntropylog' imports (the nestjs KNOWN-ISSUES #1 fix) now resolve to src/index.ts in tests, never to dist — the Release job runs the pre-commit suite before any build exists, so resolving via the package self-reference exploded with 'Failed to resolve entry for package syntropylog'.
- HUSKY: 0 on the changesets step: the bot's version-bump commit must not run local git hooks — CI already gates tests.

## Summary
<!-- What does this PR do? -->

## Related Issue
<!-- Link to the issue this PR addresses, e.g. Fixes #123 -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🔧 Maintenance / Refactor

## Checklist
- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
